### PR TITLE
Added Sandbox Resetting Functionality

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,7 +78,7 @@ include(FetchContent)
 
 FetchContent_Declare(
   rlbox
-  GIT_REPOSITORY https://github.com/PLSysSec/rlbox_api_cpp17.git)
+  GIT_REPOSITORY git@github.com:AllenAby/rlbox.git)
 FetchContent_GetProperties(rlbox)
 if(NOT rlbox_POPULATED)
   FetchContent_Populate(rlbox)
@@ -122,7 +122,7 @@ endif()
 FetchContent_Declare(
   mod_wasm2c
   GIT_REPOSITORY https://github.com/WebAssembly/wabt/
-  GIT_TAG main)
+  GIT_TAG e7c03091ccc9f53c84299aed08fa963e121afd80)
 FetchContent_GetProperties(mod_wasm2c)
 if(NOT mod_wasm2c_POPULATED)
   FetchContent_Populate(mod_wasm2c)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,7 +78,7 @@ include(FetchContent)
 
 FetchContent_Declare(
   rlbox
-  GIT_REPOSITORY git@github.com:AlexanderPortland/rlbox.git)
+  GIT_REPOSITORY git@github.com:AllenAby/rlbox.git)
 FetchContent_GetProperties(rlbox)
 if(NOT rlbox_POPULATED)
   FetchContent_Populate(rlbox)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,7 +78,7 @@ include(FetchContent)
 
 FetchContent_Declare(
   rlbox
-  GIT_REPOSITORY git@github.com:AllenAby/rlbox.git)
+  GIT_REPOSITORY git@github.com:AlexanderPortland/rlbox.git)
 FetchContent_GetProperties(rlbox)
 if(NOT rlbox_POPULATED)
   FetchContent_Populate(rlbox)

--- a/include/rlbox_wasm2c_sandbox.hpp
+++ b/include/rlbox_wasm2c_sandbox.hpp
@@ -555,15 +555,11 @@ public:
                              "Sandbox heap not aligned to 4GB");
     }
 
-    // now we want to stash our globals
-    // from g_0?? -> w2c_0x5F_stdin_used + 8;
-
-    // printf("stashing\n");
 
     // TODO: is this the right place to stash the globals?? (some things that later get initialized seem to be overwritten)
     stash_globals();
 
-    dump_memory("dumps/state_start.txt", "dumps/memory_start.txt");
+    // dump_memory("dumps/state_start.txt", "dumps/memory_start.txt");
 
     instance_initialized = true;
 
@@ -572,26 +568,23 @@ public:
 
   inline void impl_reset_sandbox() { 
 
-    dump_memory("dumps/state_pre.txt", "dumps/memory_pre.txt");
+    // dump_memory("dumps/state_pre.txt", "dumps/memory_pre.txt");
 
     // 1. wipe all memory
     reset_wasm2c_memory(&sandbox_memory_info);
 
-    FILE* fptr;
-    // first we dump wasm2c_instance state
-    fptr = fopen("dumps/globals.txt", "w");
-    fwrite(stashed_globals, stashed_globals_size, 1, fptr);
-    fclose(fptr);
+    // FILE* fptr;
+    // // first we dump wasm2c_instance state
+    // fptr = fopen("dumps/globals.txt", "w");
+    // fwrite(stashed_globals, stashed_globals_size, 1, fptr);
+    // fclose(fptr);
 
     // 2. restore stashed globals
     restore_stashed_globals();
 
-    dump_memory("dumps/state_post.txt", "dumps/memory_post.txt");
+    // dump_memory("dumps/state_post.txt", "dumps/memory_post.txt");
 
     // 3. restore wasm instance state
-
-    // TODO: we also need to make sure we modify sandbox memory metadata here
-    // so we aren't leaking memory ^^
 
     // ?. clear 'return slot' metadata for fn callback
     return_slot_size = 0;
@@ -630,59 +623,59 @@ public:
   inline void restore_stashed_globals(){
     uint8_t * stash_start =
         this->sandbox_memory_info.data + this->wasm2c_instance.w2c_g0;
-    printf("\twasm2c: restoring data segment from %p to %p\n",
-           stash_start,
-           stash_start + stashed_globals_size);
+    // printf("\twasm2c: restoring data segment from %p to %p\n",
+          //  stash_start,
+          //  stash_start + stashed_globals_size);
     std::memcpy(stash_start, stashed_globals, stashed_globals_size);
   }
 
-  inline void dump_memory(const char* state, const char* memory){
-    FILE* fptr;
-    // first we dump wasm2c_instance state
-    fptr = fopen(state, "w");
-    fprintf(fptr, "heap_base: 0x%lx\n", heap_base);
-    fprintf(fptr, "w2c_g0: 0x%x\n", wasm2c_instance.w2c_g0);
-    // fprintf(fptr, "w2c_SECRET_NUM: 0x%x\n", wasm2c_instance.w2c_SECRET_NUM);
-    // fprintf(fptr, "w2c_CONST_SECRET_NUM2: 0x%x\n\n", wasm2c_instance.w2c_CONST_SECRET_NUM2);
+  // inline void dump_memory(const char* state, const char* memory){
+  //   FILE* fptr;
+  //   // first we dump wasm2c_instance state
+  //   fptr = fopen(state, "w");
+  //   fprintf(fptr, "heap_base: 0x%lx\n", heap_base);
+  //   fprintf(fptr, "w2c_g0: 0x%x\n", wasm2c_instance.w2c_g0);
+  //   // fprintf(fptr, "w2c_SECRET_NUM: 0x%x\n", wasm2c_instance.w2c_SECRET_NUM);
+  //   // fprintf(fptr, "w2c_CONST_SECRET_NUM2: 0x%x\n\n", wasm2c_instance.w2c_CONST_SECRET_NUM2);
 
-    fprintf(fptr, "w2c_0x5F_heap_base: 0x%x\n", wasm2c_instance.w2c_0x5F_heap_base);
-    fprintf(fptr, "w2c_0x5F_stdin_used: 0x%x\n", wasm2c_instance.w2c_0x5F_stdin_used);
-    fprintf(fptr, "w2c_0x5F_stderr_used: 0x%x\n", wasm2c_instance.w2c_0x5F_stderr_used);
-    fprintf(fptr, "w2c_0x5F_stdout_used: 0x%x\n", wasm2c_instance.w2c_0x5F_stdout_used);
-    fprintf(fptr, "w2c_stderr: 0x%x\n", wasm2c_instance.w2c_stderr);
-    fprintf(fptr, "w2c_stdout: 0x%x\n", wasm2c_instance.w2c_stdout);
-    // fprintf(fptr, "w2c_0x5F_stderr_used: 0x%x\n\n", wasm2c_instance.w2c_0x5F_stderr_used);
+  //   fprintf(fptr, "w2c_0x5F_heap_base: 0x%x\n", wasm2c_instance.w2c_0x5F_heap_base);
+  //   fprintf(fptr, "w2c_0x5F_stdin_used: 0x%x\n", wasm2c_instance.w2c_0x5F_stdin_used);
+  //   fprintf(fptr, "w2c_0x5F_stderr_used: 0x%x\n", wasm2c_instance.w2c_0x5F_stderr_used);
+  //   fprintf(fptr, "w2c_0x5F_stdout_used: 0x%x\n", wasm2c_instance.w2c_0x5F_stdout_used);
+  //   fprintf(fptr, "w2c_stderr: 0x%x\n", wasm2c_instance.w2c_stderr);
+  //   fprintf(fptr, "w2c_stdout: 0x%x\n", wasm2c_instance.w2c_stdout);
+  //   // fprintf(fptr, "w2c_0x5F_stderr_used: 0x%x\n\n", wasm2c_instance.w2c_0x5F_stderr_used);
 
-    fprintf(fptr, "w2c_errno: 0x%x\n", wasm2c_instance.w2c_errno);
-    // fprintf(fptr, "w2c_0x5F_progname: 0x%x\n", wasm2c_instance.w2c_0x5F_progname);
-    // fprintf(fptr, "w2c_0x5F_progname_full: 0x%x\n", wasm2c_instance.w2c_0x5F_progname_full);
-    // fprintf(fptr, "w2c_program_invocation_short_name: 0x%x\n", wasm2c_instance.w2c_program_invocation_short_name);
-    // fprintf(fptr, "w2c_program_invocation_name: 0x%x\n\n", wasm2c_instance.w2c_program_invocation_name);
-
-
-    fprintf(fptr, "w2c_0x5F_dso_handle: 0x%x\n", wasm2c_instance.w2c_0x5F_dso_handle);
-    fprintf(fptr, "w2c_0x5F_data_end: 0x%x\n", wasm2c_instance.w2c_0x5F_data_end);
-    fprintf(fptr, "w2c_0x5F_global_base: 0x%x\n", wasm2c_instance.w2c_0x5F_global_base);
-    fprintf(fptr, "w2c_0x5F_memory_base: 0x%x\n", wasm2c_instance.w2c_0x5F_memory_base);
-    fprintf(fptr, "w2c_0x5F_table_base: 0x%x\n\n", wasm2c_instance.w2c_0x5F_table_base);
-
-    // fprintf(fptr, "w2c_0x5F_libc: 0x%x\n", wasm2c_instance.w2c_0x5F_libc);
-    // fprintf(fptr, "w2c_0x5F_hwcap: 0x%x\n", wasm2c_instance.w2c_0x5F_hwcap);
-    fprintf(fptr, "w2c_0x5F_stdout_FILE: 0x%x\n", wasm2c_instance.w2c_0x5F_stdout_FILE);
-    fprintf(fptr, "w2c_0x5F_stderr_FILE: 0x%x\n", wasm2c_instance.w2c_0x5F_stderr_FILE);
-    // fprintf(fptr, "w2c_0x5F_libc: 0x%x\n", wasm2c_instance.w2c_0x5F_libc);
-    // fprintf(fptr, "w2c_0x5F_libc: 0x%x\n", wasm2c_instance.w2c_0x5F_libc);
+  //   fprintf(fptr, "w2c_errno: 0x%x\n", wasm2c_instance.w2c_errno);
+  //   // fprintf(fptr, "w2c_0x5F_progname: 0x%x\n", wasm2c_instance.w2c_0x5F_progname);
+  //   // fprintf(fptr, "w2c_0x5F_progname_full: 0x%x\n", wasm2c_instance.w2c_0x5F_progname_full);
+  //   // fprintf(fptr, "w2c_program_invocation_short_name: 0x%x\n", wasm2c_instance.w2c_program_invocation_short_name);
+  //   // fprintf(fptr, "w2c_program_invocation_name: 0x%x\n\n", wasm2c_instance.w2c_program_invocation_name);
 
 
-    fclose(fptr);
-    // printf("dumping state succeeded (to %s)\n", state);
+  //   fprintf(fptr, "w2c_0x5F_dso_handle: 0x%x\n", wasm2c_instance.w2c_0x5F_dso_handle);
+  //   fprintf(fptr, "w2c_0x5F_data_end: 0x%x\n", wasm2c_instance.w2c_0x5F_data_end);
+  //   fprintf(fptr, "w2c_0x5F_global_base: 0x%x\n", wasm2c_instance.w2c_0x5F_global_base);
+  //   fprintf(fptr, "w2c_0x5F_memory_base: 0x%x\n", wasm2c_instance.w2c_0x5F_memory_base);
+  //   fprintf(fptr, "w2c_0x5F_table_base: 0x%x\n\n", wasm2c_instance.w2c_0x5F_table_base);
 
-    // then we dump memory contents
-    fptr = fopen(memory, "w");
-    fwrite(sandbox_memory_info.data, sandbox_memory_info.size, 1, fptr);
-    fclose(fptr);
-    // printf("dumping memory succeeded (to %s)\n", memory);
-  }
+  //   // fprintf(fptr, "w2c_0x5F_libc: 0x%x\n", wasm2c_instance.w2c_0x5F_libc);
+  //   // fprintf(fptr, "w2c_0x5F_hwcap: 0x%x\n", wasm2c_instance.w2c_0x5F_hwcap);
+  //   fprintf(fptr, "w2c_0x5F_stdout_FILE: 0x%x\n", wasm2c_instance.w2c_0x5F_stdout_FILE);
+  //   fprintf(fptr, "w2c_0x5F_stderr_FILE: 0x%x\n", wasm2c_instance.w2c_0x5F_stderr_FILE);
+  //   // fprintf(fptr, "w2c_0x5F_libc: 0x%x\n", wasm2c_instance.w2c_0x5F_libc);
+  //   // fprintf(fptr, "w2c_0x5F_libc: 0x%x\n", wasm2c_instance.w2c_0x5F_libc);
+
+
+  //   fclose(fptr);
+  //   // printf("dumping state succeeded (to %s)\n", state);
+
+  //   // then we dump memory contents
+  //   fptr = fopen(memory, "w");
+  //   fwrite(sandbox_memory_info.data, sandbox_memory_info.size, 1, fptr);
+  //   fclose(fptr);
+  //   // printf("dumping memory succeeded (to %s)\n", memory);
+  // }
 
 #undef FALLIBLE_DYNAMIC_CHECK
 

--- a/include/rlbox_wasm2c_sandbox.hpp
+++ b/include/rlbox_wasm2c_sandbox.hpp
@@ -630,6 +630,9 @@ public:
   inline void restore_stashed_globals(){
     uint8_t * stash_start =
         this->sandbox_memory_info.data + this->wasm2c_instance.w2c_g0;
+    printf("\twasm2c: restoring data segment from %p to %p\n",
+           stash_start,
+           stash_start + stashed_globals_size);
     std::memcpy(stash_start, stashed_globals, stashed_globals_size);
   }
 
@@ -637,7 +640,7 @@ public:
     FILE* fptr;
     // first we dump wasm2c_instance state
     fptr = fopen(state, "w");
-    fprintf(fptr, "heap_base: 0x%x\n", heap_base);
+    fprintf(fptr, "heap_base: %lu\n", heap_base);
     fprintf(fptr, "w2c_g0: 0x%x\n", wasm2c_instance.w2c_g0);
     fprintf(fptr, "w2c_SECRET_NUM: 0x%x\n", wasm2c_instance.w2c_SECRET_NUM);
     fprintf(fptr, "w2c_CONST_SECRET_NUM2: 0x%x\n\n", wasm2c_instance.w2c_CONST_SECRET_NUM2);

--- a/include/rlbox_wasm2c_sandbox.hpp
+++ b/include/rlbox_wasm2c_sandbox.hpp
@@ -492,6 +492,7 @@ public:
     bool infallible = true,
     const w2c_mem_capacity* custom_capacity = nullptr)
   {
+    // printf("creaitng sandbox in inner yayy\n");
     FALLIBLE_DYNAMIC_CHECK(
       infallible, instance_initialized == false, "Sandbox already initialized");
 
@@ -552,6 +553,19 @@ public:
     instance_initialized = true;
 
     return true;
+  }
+
+  inline void impl_reset_sandbox() { 
+    // how do we reset the sandbox??
+    printf("wasm2c: resetting yayyyy\n"); 
+    // 1. clear malloced memory for the sandbox -> sandbox_memory_info
+    reset_wasm2c_memory(&sandbox_memory_info);
+
+    // 2. clear return values -> 'return slot'
+    
+
+    // 3. clear registers??
+    
   }
 
 #undef FALLIBLE_DYNAMIC_CHECK

--- a/include/rlbox_wasm2c_sandbox.hpp
+++ b/include/rlbox_wasm2c_sandbox.hpp
@@ -563,7 +563,7 @@ public:
     // TODO: is this the right place to stash the globals?? (some things that later get initialized seem to be overwritten)
     stash_globals();
 
-    dump_memory("state_start.txt", "memory_start.txt");
+    dump_memory("dumps/state_start.txt", "dumps/memory_start.txt");
 
     instance_initialized = true;
 
@@ -572,21 +572,21 @@ public:
 
   inline void impl_reset_sandbox() { 
 
-    dump_memory("state_pre.txt", "memory_pre.txt");
+    dump_memory("dumps/state_pre.txt", "dumps/memory_pre.txt");
 
     // 1. wipe all memory
     reset_wasm2c_memory(&sandbox_memory_info);
 
-    // FILE* fptr;
-    // // first we dump wasm2c_instance state
-    // fptr = fopen("globals.txt", "w");
-    // fwrite(stashed_globals, stashed_globals_size, 1, fptr);
-    // fclose(fptr);
+    FILE* fptr;
+    // first we dump wasm2c_instance state
+    fptr = fopen("dumps/globals.txt", "w");
+    fwrite(stashed_globals, stashed_globals_size, 1, fptr);
+    fclose(fptr);
 
     // 2. restore stashed globals
-    restore_stashed_globals();
+    // restore_stashed_globals();
 
-    dump_memory("state_post.txt", "memory_post.txt");
+    dump_memory("dumps/state_post.txt", "dumps/memory_post.txt");
 
     // 3. restore wasm instance state
 
@@ -636,14 +636,14 @@ public:
     std::memcpy(stash_start, stashed_globals, stashed_globals_size);
   }
 
-  inline void dump_memory(char* state, char* memory){
+  inline void dump_memory(const char* state, const char* memory){
     FILE* fptr;
     // first we dump wasm2c_instance state
     fptr = fopen(state, "w");
-    fprintf(fptr, "heap_base: %lu\n", heap_base);
+    fprintf(fptr, "heap_base: 0x%lx\n", heap_base);
     fprintf(fptr, "w2c_g0: 0x%x\n", wasm2c_instance.w2c_g0);
-    fprintf(fptr, "w2c_SECRET_NUM: 0x%x\n", wasm2c_instance.w2c_SECRET_NUM);
-    fprintf(fptr, "w2c_CONST_SECRET_NUM2: 0x%x\n\n", wasm2c_instance.w2c_CONST_SECRET_NUM2);
+    // fprintf(fptr, "w2c_SECRET_NUM: 0x%x\n", wasm2c_instance.w2c_SECRET_NUM);
+    // fprintf(fptr, "w2c_CONST_SECRET_NUM2: 0x%x\n\n", wasm2c_instance.w2c_CONST_SECRET_NUM2);
 
     fprintf(fptr, "w2c_0x5F_heap_base: 0x%x\n", wasm2c_instance.w2c_0x5F_heap_base);
     fprintf(fptr, "w2c_0x5F_stdin_used: 0x%x\n", wasm2c_instance.w2c_0x5F_stdin_used);
@@ -651,13 +651,13 @@ public:
     fprintf(fptr, "w2c_0x5F_stdout_used: 0x%x\n", wasm2c_instance.w2c_0x5F_stdout_used);
     fprintf(fptr, "w2c_stderr: 0x%x\n", wasm2c_instance.w2c_stderr);
     fprintf(fptr, "w2c_stdout: 0x%x\n", wasm2c_instance.w2c_stdout);
-    fprintf(fptr, "w2c_0x5F_stderr_used: 0x%x\n\n", wasm2c_instance.w2c_0x5F_stderr_used);
+    // fprintf(fptr, "w2c_0x5F_stderr_used: 0x%x\n\n", wasm2c_instance.w2c_0x5F_stderr_used);
 
     fprintf(fptr, "w2c_errno: 0x%x\n", wasm2c_instance.w2c_errno);
-    fprintf(fptr, "w2c_0x5F_progname: 0x%x\n", wasm2c_instance.w2c_0x5F_progname);
-    fprintf(fptr, "w2c_0x5F_progname_full: 0x%x\n", wasm2c_instance.w2c_0x5F_progname_full);
-    fprintf(fptr, "w2c_program_invocation_short_name: 0x%x\n", wasm2c_instance.w2c_program_invocation_short_name);
-    fprintf(fptr, "w2c_program_invocation_name: 0x%x\n\n", wasm2c_instance.w2c_program_invocation_name);
+    // fprintf(fptr, "w2c_0x5F_progname: 0x%x\n", wasm2c_instance.w2c_0x5F_progname);
+    // fprintf(fptr, "w2c_0x5F_progname_full: 0x%x\n", wasm2c_instance.w2c_0x5F_progname_full);
+    // fprintf(fptr, "w2c_program_invocation_short_name: 0x%x\n", wasm2c_instance.w2c_program_invocation_short_name);
+    // fprintf(fptr, "w2c_program_invocation_name: 0x%x\n\n", wasm2c_instance.w2c_program_invocation_name);
 
 
     fprintf(fptr, "w2c_0x5F_dso_handle: 0x%x\n", wasm2c_instance.w2c_0x5F_dso_handle);
@@ -666,12 +666,12 @@ public:
     fprintf(fptr, "w2c_0x5F_memory_base: 0x%x\n", wasm2c_instance.w2c_0x5F_memory_base);
     fprintf(fptr, "w2c_0x5F_table_base: 0x%x\n\n", wasm2c_instance.w2c_0x5F_table_base);
 
-    fprintf(fptr, "w2c_0x5F_libc: 0x%x\n", wasm2c_instance.w2c_0x5F_libc);
-    fprintf(fptr, "w2c_0x5F_hwcap: 0x%x\n", wasm2c_instance.w2c_0x5F_hwcap);
+    // fprintf(fptr, "w2c_0x5F_libc: 0x%x\n", wasm2c_instance.w2c_0x5F_libc);
+    // fprintf(fptr, "w2c_0x5F_hwcap: 0x%x\n", wasm2c_instance.w2c_0x5F_hwcap);
     fprintf(fptr, "w2c_0x5F_stdout_FILE: 0x%x\n", wasm2c_instance.w2c_0x5F_stdout_FILE);
     fprintf(fptr, "w2c_0x5F_stderr_FILE: 0x%x\n", wasm2c_instance.w2c_0x5F_stderr_FILE);
-    fprintf(fptr, "w2c_0x5F_libc: 0x%x\n", wasm2c_instance.w2c_0x5F_libc);
-    fprintf(fptr, "w2c_0x5F_libc: 0x%x\n", wasm2c_instance.w2c_0x5F_libc);
+    // fprintf(fptr, "w2c_0x5F_libc: 0x%x\n", wasm2c_instance.w2c_0x5F_libc);
+    // fprintf(fptr, "w2c_0x5F_libc: 0x%x\n", wasm2c_instance.w2c_0x5F_libc);
 
 
     fclose(fptr);

--- a/include/rlbox_wasm2c_sandbox.hpp
+++ b/include/rlbox_wasm2c_sandbox.hpp
@@ -584,7 +584,7 @@ public:
     fclose(fptr);
 
     // 2. restore stashed globals
-    // restore_stashed_globals();
+    restore_stashed_globals();
 
     dump_memory("dumps/state_post.txt", "dumps/memory_post.txt");
 

--- a/include/rlbox_wasm2c_sandbox.hpp
+++ b/include/rlbox_wasm2c_sandbox.hpp
@@ -559,14 +559,8 @@ public:
 
   inline void impl_reset_sandbox() { 
     // 1. clear malloced memory for the sandbox -> sandbox_memory_info
-    // NOTE: this reset seems to fuck up printing in subsequent functions, even if no printing is used
-    //              i think bc it writes null bytes to the console addr? and it prints one null byte using up the print
-    //              don't think its an issue though bc we dont want there to be printing
-    //              and *functions should still work properly*
-    // FIXME: (probably intendend) but this clears both global vars and consts
-    //        with a new sandbox instance they would be re-set to intial values
-    //        what does this mean for developer effort??
-    //            could they just use macros instead?
+    // NOTE: the reset overwrites the console address so it counts as the one print allowed in the sandbox
+    //       this has to be the case though bc stdout could be used to leak the addr
     reset_wasm2c_memory(&sandbox_memory_info);
 
     // 2. clear return values -> 'return slot'

--- a/include/wasm2c_rt_mem.h
+++ b/include/wasm2c_rt_mem.h
@@ -38,6 +38,7 @@ extern "C"
     uint32_t initial_pages,
     const w2c_mem_capacity* custom_capacity);
   void destroy_wasm2c_memory(wasm_rt_memory_t* memory);
+  void reset_wasm2c_memory(wasm_rt_memory_t* memory);
 
 #ifdef __cplusplus
 }

--- a/src/wasm2c_rt_mem.c
+++ b/src/wasm2c_rt_mem.c
@@ -182,7 +182,7 @@ void reset_wasm2c_memory(wasm_rt_memory_t* memory){
   if (memory->data != 0) {
     // const size_t opt_offset = 0xff000; // TODO: programatically set this based on sandbox metadata
                                           // havent found a pointer to the bottom of the stack in metadata yet though
-    const size_t opt_offset = 0xff000;
+    const size_t opt_offset = 0;
     const uint64_t size_to_wipe = memory->size - opt_offset;
     const uint64_t addr_to_wipe = memory->data + opt_offset;
 
@@ -192,7 +192,7 @@ void reset_wasm2c_memory(wasm_rt_memory_t* memory){
     // fclose(fptr);
     // printf("dumping succeeded\n");
     
-    printf("\twasm2c: wiping memory at 0x%llx, size: 0x%llx\n", addr_to_wipe, size_to_wipe);
+    // printf("\twasm2c: wiping memory at 0x%llx, size: 0x%llx\n", addr_to_wipe, size_to_wipe);
     memset((void*)addr_to_wipe, 0, size_to_wipe);
   }
 }

--- a/src/wasm2c_rt_mem.c
+++ b/src/wasm2c_rt_mem.c
@@ -452,3 +452,26 @@ static int os_mmap_commit(void* addr, size_t size, int prot)
 #else
 #  error "Unknown OS"
 #endif
+
+void reset_wasm2c_memory(wasm_rt_memory_t* memory){
+  printf("wasm2c: wiping memory at %p\n", memory);
+
+  if (memory->data != 0) {
+    //           memsetting works with 0x110000 size of total, but anything more fails consistently
+    const uint64_t heap_reserve_size = 0x110000;
+    // compute_heap_reserve_space(memory->max_pages);
+    printf("\twasm2c: computed heap to be 0x%llx\n", compute_heap_reserve_space(memory->max_pages));
+
+    uint64_t page_size = (uint64_t)os_getpagesize();
+    uint64_t request_size = (heap_reserve_size + page_size - 1) & ~(page_size - 1);
+    printf("\tcalculated page size: 0x%llx and final req_size: 0x%llx\n",
+           page_size,
+           request_size);
+           
+    printf("\twasm2c: wiping memory at %p, size: 0x%llx\n", memory, heap_reserve_size);
+    memset(memory->data, 0x0, request_size);
+    printf("\twasm2c: memset that shit, now data: %llx\n", *(long long unsigned*)memory->data);
+    // os_munmap(memory->data, heap_reserve_size);
+    // memory->data = 0;
+  }
+}

--- a/src/wasm2c_rt_mem.c
+++ b/src/wasm2c_rt_mem.c
@@ -177,26 +177,22 @@ void destroy_wasm2c_memory(wasm_rt_memory_t* memory)
   }
 }
 
+FILE *fptr;
+
 void reset_wasm2c_memory(wasm_rt_memory_t* memory){
-
+  
   if (memory->data != 0) {
-    //           memsetting works with 0x110000 size of total, but anything more fails consistently
-    // TODO: why is it that specifically??
-    //    maybe you run into stack memory or smth that corrupts the operation
-    const uint64_t heap_reserve_size = 
-      // compute_heap_reserve_space(memory->max_pages);
-      0x110000;
-    printf("\twasm2c: computed heap to be 0x%llx\n", compute_heap_reserve_space(memory->max_pages));
-
-    uint64_t page_size = (uint64_t)os_getpagesize();
-    uint64_t request_size = (heap_reserve_size + page_size - 1) & ~(page_size - 1);
-    printf("\tcalculated page size: 0x%llx and final req_size: 0x%llx\n",
-           page_size,
-           request_size);
-           
-    printf("\twasm2c: wiping heap memory at %p, size: 0x%llx\n", memory, heap_reserve_size);
-    memset(memory->data, 0x0, request_size);
-    printf("\t\twasm2c: memset that shit, now data: %llx\n", *(long long unsigned*)memory->data);
+    // TODO: more fine-grained erasure?? -> protect constant global vars that would be preserved when re-making sandbox
+    const uint64_t mem_size = memory->size;
+    
+    // // dump memory if you want to see its contents
+    // fptr = fopen("memory_prewipe.txt", "w");
+    // fwrite(memory->data, mem_size, 1, fptr);
+    // fclose(fptr);
+    // printf("dumping succeeded\n");
+    
+    printf("\twasm2c: wiping heap memory at %p, size: 0x%llx\n", memory->data, mem_size);
+    memset(memory->data, 0x0, mem_size);
   }
 }
 

--- a/src/wasm2c_rt_mem.c
+++ b/src/wasm2c_rt_mem.c
@@ -183,8 +183,18 @@ void reset_wasm2c_memory(wasm_rt_memory_t* memory){
     const uint64_t size_to_wipe = memory->size - opt_offset;
     const uint64_t addr_to_wipe = memory->data + opt_offset;
 
+    // #ifdef __linux__
+    // // If we are using linux, we can use madvise() instead of memset because it's faster.
+    // madvise((void*)addr_to_wipe, size_to_wipe, MADV_REMOVE);
+
+    // #else
+    // TODO: is there a better way to do this on mac?
+
+    // If not, we can just memset it normally.
     memset((void*)addr_to_wipe, 0, size_to_wipe);
+    // #endif
   }
+  
 }
 
 #undef WASM_HEAP_DEFAULT_MAX_PAGES

--- a/src/wasm2c_rt_mem.c
+++ b/src/wasm2c_rt_mem.c
@@ -178,21 +178,11 @@ void destroy_wasm2c_memory(wasm_rt_memory_t* memory)
 }
 
 void reset_wasm2c_memory(wasm_rt_memory_t* memory){
-
   if (memory->data != 0) {
-    // const size_t opt_offset = 0xff000; // TODO: programatically set this based on sandbox metadata
-                                          // havent found a pointer to the bottom of the stack in metadata yet though
     const size_t opt_offset = 0;
     const uint64_t size_to_wipe = memory->size - opt_offset;
     const uint64_t addr_to_wipe = memory->data + opt_offset;
 
-    // // dump memory if you want to see its contents
-    // fptr = fopen("memory_prewipe.txt", "w");
-    // fwrite(memory->data, mem_size, 1, fptr);
-    // fclose(fptr);
-    // printf("dumping succeeded\n");
-    
-    // printf("\twasm2c: wiping memory at 0x%llx, size: 0x%llx\n", addr_to_wipe, size_to_wipe);
     memset((void*)addr_to_wipe, 0, size_to_wipe);
   }
 }

--- a/src/wasm2c_rt_mem.c
+++ b/src/wasm2c_rt_mem.c
@@ -179,9 +179,9 @@ void destroy_wasm2c_memory(wasm_rt_memory_t* memory)
 
 void reset_wasm2c_memory(wasm_rt_memory_t* memory){
 
-  // TODO: more fine-grained erasure?? -> protect constant global vars that would be preserved when re-making sandbox
   if (memory->data != 0) {
     // const size_t opt_offset = 0xff000; // TODO: programatically set this based on sandbox metadata
+                                          // havent found a pointer to the bottom of the stack in metadata yet though
     const size_t opt_offset = 0xff000;
     const uint64_t size_to_wipe = memory->size - opt_offset;
     const uint64_t addr_to_wipe = memory->data + opt_offset;
@@ -192,8 +192,8 @@ void reset_wasm2c_memory(wasm_rt_memory_t* memory){
     // fclose(fptr);
     // printf("dumping succeeded\n");
     
-    printf("\twasm2c: wiping memory at %p, size: 0x%llx\n", addr_to_wipe, size_to_wipe);
-    memset(addr_to_wipe, 0, size_to_wipe);
+    printf("\twasm2c: wiping memory at 0x%llx, size: 0x%llx\n", addr_to_wipe, size_to_wipe);
+    memset((void*)addr_to_wipe, 0, size_to_wipe);
   }
 }
 

--- a/src/wasm2c_rt_mem.c
+++ b/src/wasm2c_rt_mem.c
@@ -178,11 +178,13 @@ void destroy_wasm2c_memory(wasm_rt_memory_t* memory)
 }
 
 void reset_wasm2c_memory(wasm_rt_memory_t* memory){
-  
+
+  // TODO: more fine-grained erasure?? -> protect constant global vars that would be preserved when re-making sandbox
   if (memory->data != 0) {
-    // TODO: more fine-grained erasure?? -> protect constant global vars that would be preserved when re-making sandbox
-    const uint64_t mem_size = memory->size;
-    const size_t opt_offset = 0xff000; // TODO: programatically set this based on sandbox metadata
+    // const size_t opt_offset = 0xff000; // TODO: programatically set this based on sandbox metadata
+    const size_t opt_offset = 0xff000;
+    const uint64_t size_to_wipe = memory->size - opt_offset;
+    const uint64_t addr_to_wipe = memory->data + opt_offset;
 
     // // dump memory if you want to see its contents
     // fptr = fopen("memory_prewipe.txt", "w");
@@ -190,8 +192,8 @@ void reset_wasm2c_memory(wasm_rt_memory_t* memory){
     // fclose(fptr);
     // printf("dumping succeeded\n");
     
-    // printf("\twasm2c: wiping memory at %p, size: 0x%llx\n", memory->data + opt_offset, mem_size - opt_offset);
-    memset(memory->data + opt_offset, 0, mem_size - opt_offset);
+    printf("\twasm2c: wiping memory at %p, size: 0x%llx\n", addr_to_wipe, size_to_wipe);
+    memset(addr_to_wipe, 0, size_to_wipe);
   }
 }
 

--- a/src/wasm2c_rt_mem.c
+++ b/src/wasm2c_rt_mem.c
@@ -177,22 +177,21 @@ void destroy_wasm2c_memory(wasm_rt_memory_t* memory)
   }
 }
 
-FILE *fptr;
-
 void reset_wasm2c_memory(wasm_rt_memory_t* memory){
   
   if (memory->data != 0) {
     // TODO: more fine-grained erasure?? -> protect constant global vars that would be preserved when re-making sandbox
     const uint64_t mem_size = memory->size;
-    
+    const size_t opt_offset = 0xff000; // TODO: programatically set this based on sandbox metadata
+
     // // dump memory if you want to see its contents
     // fptr = fopen("memory_prewipe.txt", "w");
     // fwrite(memory->data, mem_size, 1, fptr);
     // fclose(fptr);
     // printf("dumping succeeded\n");
     
-    printf("\twasm2c: wiping heap memory at %p, size: 0x%llx\n", memory->data, mem_size);
-    memset(memory->data, 0x0, mem_size);
+    // printf("\twasm2c: wiping memory at %p, size: 0x%llx\n", memory->data + opt_offset, mem_size - opt_offset);
+    memset(memory->data + opt_offset, 0, mem_size - opt_offset);
   }
 }
 

--- a/src/wasm2c_rt_mem.c
+++ b/src/wasm2c_rt_mem.c
@@ -36,6 +36,8 @@ static void* os_mmap_aligned(void* addr,
                              size_t alignment_offset);
 // Unreserve the memory space
 static void os_munmap(void* addr, size_t size);
+// Get OS pagesize
+static size_t os_getpagesize();
 // Allocates and sets the permissions on the previously reserved memory space
 // Returns 0 on success, non zero on failure.
 static int os_mmap_commit(void* curr_heap_end_pointer,
@@ -172,6 +174,29 @@ void destroy_wasm2c_memory(wasm_rt_memory_t* memory)
       compute_heap_reserve_space(memory->max_pages);
     os_munmap(memory->data, heap_reserve_size);
     memory->data = 0;
+  }
+}
+
+void reset_wasm2c_memory(wasm_rt_memory_t* memory){
+
+  if (memory->data != 0) {
+    //           memsetting works with 0x110000 size of total, but anything more fails consistently
+    // TODO: why is it that specifically??
+    //    maybe you run into stack memory or smth that corrupts the operation
+    const uint64_t heap_reserve_size = 
+      // compute_heap_reserve_space(memory->max_pages);
+      0x110000;
+    printf("\twasm2c: computed heap to be 0x%llx\n", compute_heap_reserve_space(memory->max_pages));
+
+    uint64_t page_size = (uint64_t)os_getpagesize();
+    uint64_t request_size = (heap_reserve_size + page_size - 1) & ~(page_size - 1);
+    printf("\tcalculated page size: 0x%llx and final req_size: 0x%llx\n",
+           page_size,
+           request_size);
+           
+    printf("\twasm2c: wiping heap memory at %p, size: 0x%llx\n", memory, heap_reserve_size);
+    memset(memory->data, 0x0, request_size);
+    printf("\t\twasm2c: memset that shit, now data: %llx\n", *(long long unsigned*)memory->data);
   }
 }
 
@@ -452,26 +477,3 @@ static int os_mmap_commit(void* addr, size_t size, int prot)
 #else
 #  error "Unknown OS"
 #endif
-
-void reset_wasm2c_memory(wasm_rt_memory_t* memory){
-  printf("wasm2c: wiping memory at %p\n", memory);
-
-  if (memory->data != 0) {
-    //           memsetting works with 0x110000 size of total, but anything more fails consistently
-    const uint64_t heap_reserve_size = 0x110000;
-    // compute_heap_reserve_space(memory->max_pages);
-    printf("\twasm2c: computed heap to be 0x%llx\n", compute_heap_reserve_space(memory->max_pages));
-
-    uint64_t page_size = (uint64_t)os_getpagesize();
-    uint64_t request_size = (heap_reserve_size + page_size - 1) & ~(page_size - 1);
-    printf("\tcalculated page size: 0x%llx and final req_size: 0x%llx\n",
-           page_size,
-           request_size);
-           
-    printf("\twasm2c: wiping memory at %p, size: 0x%llx\n", memory, heap_reserve_size);
-    memset(memory->data, 0x0, request_size);
-    printf("\twasm2c: memset that shit, now data: %llx\n", *(long long unsigned*)memory->data);
-    // os_munmap(memory->data, heap_reserve_size);
-    // memory->data = 0;
-  }
-}

--- a/src/wasm2c_rt_minwasi.c
+++ b/src/wasm2c_rt_minwasi.c
@@ -482,9 +482,12 @@ u32 w2c_wasi__snapshot__preview1_fd_write(
   u32 iovcnt,
   u32 pnum)
 {
+  return WASI_BADF_ERROR;
   if (fd != WASM_STDOUT && fd != WASM_STDERR) {
     return WASI_BADF_ERROR;
   }
+
+  printf("miniwasi: trying to access fd %d\n", fd);
 
   u32 num = 0;
   for (u32 i = 0; i < iovcnt; i++) {

--- a/src/wasm2c_rt_minwasi.c
+++ b/src/wasm2c_rt_minwasi.c
@@ -482,12 +482,12 @@ u32 w2c_wasi__snapshot__preview1_fd_write(
   u32 iovcnt,
   u32 pnum)
 {
-  return WASI_BADF_ERROR;
+  return WASI_BADF_ERROR; // return to prevent printing
   if (fd != WASM_STDOUT && fd != WASM_STDERR) {
     return WASI_BADF_ERROR;
   }
 
-  printf("miniwasi: trying to access fd %d\n", fd);
+  // printf("miniwasi: trying to access fd %d\n", fd);
 
   u32 num = 0;
   for (u32 i = 0; i < iovcnt; i++) {


### PR DESCRIPTION
This adds functionality to wasm2c sandboxes so they can be reset for reuse. Sandbox memory is totally wiped and then the data segment is returned to its initial state to prevent potential data leaks. Sandbox metadata is also reset as if the sandbox had just been created.